### PR TITLE
feat: fix monorepo issues with `sherif`

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -28,11 +28,11 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@sentry/nextjs": "^8",
+    "@supabase/sentry-js-integration": "^0.2.0",
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "@sentry/nextjs": "^8",
-    "@supabase/sentry-js-integration": "^0.2.0"
+    "typescript": "^5"
   }
 }

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -23,8 +23,8 @@
     "next-safe-action": "^7.8.1",
     "next-themes": "^0.3.0",
     "nuqs": "^1.18.0",
-    "react": "^18",
-    "react-dom": "^18",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -33,6 +33,6 @@
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "typescript": "^5"
+    "typescript": "^5.5.4"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,14 +17,14 @@
     "@v1/ui": "workspace:*",
     "geist": "^1.3.1",
     "next": "14.2.7",
-    "react": "^18",
-    "react-dom": "^18",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "usehooks-ts": "^3.1.0"
   },
   "devDependencies": {
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "typescript": "^5"
+    "typescript": "^5.5.4"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,9 +12,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@v1/ui": "workspace:*",
-    "@v1/analytics": "workspace:*",
     "@calcom/embed-react": "^1.5.0",
+    "@v1/analytics": "workspace:*",
+    "@v1/ui": "workspace:*",
     "geist": "^1.3.1",
     "next": "14.2.7",
     "react": "^18",
@@ -22,9 +22,9 @@
     "usehooks-ts": "^3.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^22",
     "@types/react": "^18",
-    "@types/react-dom": "^18"
+    "@types/react-dom": "^18",
+    "typescript": "^5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test": "turbo test --parallel",
     "format": "biome format --write .",
     "lint": "turbo lint && manypkg check",
+    "lint:repo": "bunx sherif@latest",
+    "lint:repo:fix": "bunx sherif@latest --fix",
     "typecheck": "turbo typecheck"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "turbo lint && manypkg check",
     "typecheck": "turbo typecheck"
   },
-  "dependencies": {
+  "devDependencies": {
     "@biomejs/biome": "1.8.3",
     "@manypkg/cli": "^0.21.4",
     "@t3-oss/env-nextjs": "^0.11.1",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -11,9 +11,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@openpanel/nextjs": "^1.0.0",
     "@v1/logger": "workspace:*",
-    "@vercel/functions": "^1.4.1",
-    "@openpanel/nextjs": "^1.0.0"
+    "@vercel/functions": "^1.4.1"
   },
   "exports": {
     "./server": "./src/server.ts",

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -10,8 +10,8 @@
     "db:generate": "supabase gen types --lang=typescript --project-id $PROJECT_ID --schema public > src/types/db.ts"
   },
   "dependencies": {
-    "@v1/logger": "workspace:*",
     "@supabase/ssr": "^0.5.1",
+    "@v1/logger": "workspace:*",
     "react": "^18.3.1",
     "server-only": "^0.0.1",
     "supabase": "^1.191.3"


### PR DESCRIPTION
This PR adds [Sherif](https://github.com/quiibz/sherif), a monorepo linter, and fixes the current issues that were reported by running `bunx sherif@latest`:

- Move the root `dependencies` to `devDependencies`
- Order alphabetically all `dependencies` and `devDependencies`
- Use the same version across the monorepo for `typescript` (`^5.5.4`), `react` (`^18.3.1`), and `react-dom` (`^18.3.1`)
- Add two new `lint:repo` and `lint:repo:fix` scripts to run Sherif and fix issues with Sherif

Each step is in a separate commit, so feel to just apply the fixes without adding the two new `scripts` by dropping 4e6928ba7066363a2844c20adb1be8628f47435b if you don't want to add Sherif.


<img width="959" alt="Screenshot 2024-09-01 at 09 13 33" src="https://github.com/user-attachments/assets/7343cb61-8016-4bd1-bb5c-c88e74ac1d7c">