### PR TITLE
build(apps): use next lint instead of biome

### DIFF
--- a/apps/app/.eslintrc.json
+++ b/apps/app/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
   experimental: {
     instrumentationHook: process.env.NODE_ENV === "production",
   },
+  reactStrictMode: true,
 };
 
 export default withSentryConfig(nextConfig, {

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "clean": "git clean -xdf .next .turbo node_modules",
-    "lint": "biome lint",
+    "lint": "next lint",
     "format": "biome format --write .",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    reactStrictMode: true,
+};
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev -p 3001",
     "build": "next build",
     "clean": "git clean -xdf .next .turbo node_modules",
-    "lint": "biome lint",
+    "lint": "next lint",
     "format": "biome format --write .",
     "start": "next start",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
At the time of writing next lint does not support biome vid. https://github.com/vercel/next.js/discussions/59347 
This might lead to some uncaught errors/warnings during the lint task. This PR seeks to fix that. It might be a bit opinionated (using the strict config by default) but I consider it a best practice. Let me know wdyt. 

Cheers!