### PR TITLE
Add dev:api script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:web": "turbo dev --filter=@v1/web",
     "dev:jobs": "turbo jobs --filter=@v1/jobs",
     "dev:app": "turbo dev --filter=@v1/app",
+    "dev:api": "turbo dev --filter=@v1/api",
     "start:web": "turbo start --filter=@v1/web",
     "start:app": "turbo start --filter=@v1/app",
     "test": "turbo test --parallel",
@@ -25,5 +26,10 @@
     "turbo": "2.1.1",
     "typescript": "^5.5.4"
   },
-  "packageManager": "bun@1.1.26"
+  "packageManager": "bun@1.1.26",
+  "trustedDependencies": [
+    "@biomejs/biome",
+    "@sentry/cli",
+    "protobufjs"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,5 @@
     "turbo": "2.1.1",
     "typescript": "^5.5.4"
   },
-  "packageManager": "bun@1.1.26",
-  "trustedDependencies": [
-    "@biomejs/biome",
-    "@sentry/cli",
-    "protobufjs"
-  ]
+  "packageManager": "bun@1.1.26"
 }


### PR DESCRIPTION
This was a source of confusion for me when following the intro docs, which have a reference to `bun dev:api` which doesn't exist. This just adds a script to match the docs.